### PR TITLE
Add link to contribute-to-open-source

### DIFF
--- a/Newbie Guides.md
+++ b/Newbie Guides.md
@@ -7,4 +7,4 @@ to contribute to their projects.
 4. [How to become a MediaWiki hacker?](https://www.mediawiki.org/wiki/How_to_become_a_MediaWiki_hacker)
 5. [Apache Newcomers Guide](http://community.apache.org/newcomers/index.html)
 6. [KDE guide](https://community.kde.org/Get_Involved)
-
+7. [Learn the GitHub workflow](https://github.com/danthareja/contribute-to-open-source)


### PR DESCRIPTION
Hey there!

I recently released a project that aims to empower new contributors by teaching them the mechanics of the GitHub pull request process in an interactive experience.

https://github.com/danthareja/contribute-to-open-source

In this project, users are given tests and tasked with writing code to DRY up an existing codebase. When they submit a PR, there's some fun back and forth with a bot that interprets their CI results and eventually merges their code.

I'd like to increase exposure to this project to as many new contributors as possible, and thought it would make a nice addition to this page.